### PR TITLE
feat: initialize supabase and alembic with database migration and initial schema

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,22 @@
+# ─── Supabase ────────────────────────────────────────────────
+SUPABASE_URL=https://<project-ref>.supabase.co
+SUPABASE_ANON_KEY=<anon-key>
+SUPABASE_SERVICE_ROLE_KEY=<service-role-key>
+
+# ─── PostgreSQL (direct connection for Alembic/SQLAlchemy) ───
+DATABASE_URL=postgresql+asyncpg://postgres:<password>@db.<project-ref>.supabase.co:5432/postgres
+
+# ─── Redis (self-hosted Docker container) ────────────────────
+REDIS_URL=redis://redis:6379/0   # use redis://localhost:6379/0 outside Docker
+
+# ─── OpenAI ──────────────────────────────────────────────────
+OPENAI_API_KEY=sk-...
+
+# ─── Application ─────────────────────────────────────────────
+SECRET_KEY=<random-64-char-hex>
+ENVIRONMENT=development      # development | production
+FRONTEND_URL=http://localhost:5173
+
+# ─── Embeddings ──────────────────────────────────────────────
+EMBEDDING_MODEL=BAAI/bge-small-en-v1.5
+EMBEDDING_CACHE_DIR=./model_cache

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,149 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts.
+# this is typically a path given in POSIX (e.g. forward slashes)
+# format, relative to the token %(here)s which refers to the location of this
+# ini file
+script_location = %(here)s/alembic
+
+# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
+# Uncomment the line below if you want the files to be prepended with date and time
+# see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
+# for all available tokens
+# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+# Or organize into date-based subdirectories (requires recursive_version_locations = true)
+# file_template = %%(year)d/%%(month).2d/%%(day).2d_%%(hour).2d%%(minute).2d_%%(second).2d_%%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.  for multiple paths, the path separator
+# is defined by "path_separator" below.
+prepend_sys_path = .
+
+
+# timezone to use when rendering the date within the migration file
+# as well as the filename.
+# If specified, requires the tzdata library which can be installed by adding
+# `alembic[tz]` to the pip requirements.
+# string value is passed to ZoneInfo()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; This defaults
+# to <script_location>/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path.
+# The path separator used here should be the separator specified by "path_separator"
+# below.
+# version_locations = %(here)s/bar:%(here)s/bat:%(here)s/alembic/versions
+
+# path_separator; This indicates what character is used to split lists of file
+# paths, including version_locations and prepend_sys_path within configparser
+# files such as alembic.ini.
+# The default rendered in new alembic.ini files is "os", which uses os.pathsep
+# to provide os-dependent path splitting.
+#
+# Note that in order to support legacy alembic.ini files, this default does NOT
+# take place if path_separator is not present in alembic.ini.  If this
+# option is omitted entirely, fallback logic is as follows:
+#
+# 1. Parsing of the version_locations option falls back to using the legacy
+#    "version_path_separator" key, which if absent then falls back to the legacy
+#    behavior of splitting on spaces and/or commas.
+# 2. Parsing of the prepend_sys_path option falls back to the legacy
+#    behavior of splitting on spaces, commas, or colons.
+#
+# Valid values for path_separator are:
+#
+# path_separator = :
+# path_separator = ;
+# path_separator = space
+# path_separator = newline
+#
+# Use os.pathsep. Default configuration used for new projects.
+path_separator = os
+
+# set to 'true' to search source files recursively
+# in each "version_locations" directory
+# new in Alembic version 1.10
+# recursive_version_locations = false
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+# database URL.  This is consumed by the user-maintained env.py script only.
+# other means of configuring database URLs may be customized within the env.py
+# file.
+sqlalchemy.url = driver://user:pass@localhost/dbname
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# lint with attempts to fix using "ruff" - use the module runner, against the "ruff" module
+# hooks = ruff
+# ruff.type = module
+# ruff.module = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Alternatively, use the exec runner to execute a binary found on your PATH
+# hooks = ruff
+# ruff.type = exec
+# ruff.executable = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Logging configuration.  This is also consumed by the user-maintained
+# env.py script only.
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/backend/alembic/README
+++ b/backend/alembic/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,82 @@
+import os
+from logging.config import fileConfig
+
+from dotenv import load_dotenv
+from sqlalchemy import engine_from_config, pool
+
+from alembic import context
+
+load_dotenv()
+
+config = context.config
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+
+if DATABASE_URL:
+    config.set_main_option("sqlalchemy.url", DATABASE_URL)
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = None
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/script.py.mako
+++ b/backend/alembic/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}

--- a/backend/alembic/versions/c1a1995a14ac_init_schema.py
+++ b/backend/alembic/versions/c1a1995a14ac_init_schema.py
@@ -1,0 +1,154 @@
+"""init schema
+
+Revision ID: c1a1995a14ac
+Revises:
+Create Date: 2026-03-23 18:51:36.608085
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c1a1995a14ac"
+down_revision: str | Sequence[str] | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Extensions
+    op.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";')
+    op.execute("CREATE EXTENSION IF NOT EXISTS vector;")
+
+    # Vaults
+    op.execute("""
+    CREATE TABLE IF NOT EXISTS vaults (
+        id           UUID        PRIMARY KEY DEFAULT uuid_generate_v4(),
+        user_id      UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+        name         TEXT        NOT NULL CHECK (char_length(name) BETWEEN 1 AND 100),
+        description  TEXT,
+        metadata     JSONB       DEFAULT '{}'::jsonb,
+        created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+    """)
+
+    # Files
+    op.execute("""
+    CREATE TABLE IF NOT EXISTS files (
+        id             UUID        PRIMARY KEY DEFAULT uuid_generate_v4(),
+        vault_id       UUID        NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+        user_id        UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+        storage_path   TEXT        NOT NULL,
+        original_name  TEXT        NOT NULL,
+        file_type      TEXT        NOT NULL CHECK (file_type IN ('pdf','image','docx','txt','note')),
+        mime_type      TEXT,
+        size_bytes     BIGINT,
+        page_count     INTEGER,
+        status         TEXT        NOT NULL DEFAULT 'processing'
+                                   CHECK (status IN ('processing','ready','failed')),
+        error_message  TEXT,
+        total_chunks   INTEGER     DEFAULT 0,
+        total_tokens   INTEGER     DEFAULT 0,
+        metadata       JSONB       DEFAULT '{}'::jsonb,
+        created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+    """)
+
+    # Chunks
+    op.execute("""
+    CREATE TABLE IF NOT EXISTS chunks (
+        id               UUID        PRIMARY KEY DEFAULT uuid_generate_v4(),
+        file_id          UUID        NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+        vault_id         UUID        NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+        content          TEXT        NOT NULL,
+        chunk_index      INTEGER     NOT NULL,
+        page_number      INTEGER,
+        section_title    TEXT,
+        token_count      INTEGER,
+        embedding        VECTOR(384),
+        ts_vector        TSVECTOR GENERATED ALWAYS AS (to_tsvector('english', content)) STORED,
+        importance_score FLOAT       DEFAULT 1.0,
+        metadata         JSONB       DEFAULT '{}'::jsonb,
+        created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+    """)
+
+    # Indexes
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_chunks_file_index ON chunks (file_id, chunk_index);"
+    )
+    op.execute("""
+    CREATE INDEX IF NOT EXISTS idx_chunks_embedding ON chunks
+        USING hnsw (embedding vector_cosine_ops)
+        WITH (m = 16, ef_construction = 64);
+    """)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_chunks_ts_vector ON chunks USING gin(ts_vector);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_chunks_metadata ON chunks USING gin(metadata);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_chunks_vault_file ON chunks (vault_id, file_id);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_files_vault_status ON files (vault_id, status);"
+    )
+    op.execute("CREATE INDEX IF NOT EXISTS idx_files_user ON files (user_id);")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_vaults_user ON vaults (user_id);")
+
+    # updated_at trigger function
+    op.execute("""
+    CREATE OR REPLACE FUNCTION update_updated_at()
+    RETURNS TRIGGER LANGUAGE plpgsql AS $$
+    BEGIN NEW.updated_at = now(); RETURN NEW; END;
+    $$;
+    """)
+
+    op.execute("""
+    CREATE TRIGGER vaults_updated_at BEFORE UPDATE ON vaults
+        FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+    """)
+    op.execute("""
+    CREATE TRIGGER files_updated_at BEFORE UPDATE ON files
+        FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+    """)
+
+    # Row Level Security
+    op.execute("ALTER TABLE vaults ENABLE ROW LEVEL SECURITY;")
+    op.execute("ALTER TABLE files  ENABLE ROW LEVEL SECURITY;")
+    op.execute("ALTER TABLE chunks ENABLE ROW LEVEL SECURITY;")
+
+    op.execute("""
+    CREATE POLICY vaults_owner ON vaults
+        USING (user_id = auth.uid());
+    """)
+    op.execute("""
+    CREATE POLICY files_owner ON files
+        USING (user_id = auth.uid());
+    """)
+    op.execute("""
+    CREATE POLICY chunks_owner ON chunks
+        USING (vault_id IN (SELECT id FROM vaults WHERE user_id = auth.uid()));
+    """)
+
+
+def downgrade() -> None:
+    # RLS policies
+    op.execute("DROP POLICY IF EXISTS chunks_owner ON chunks;")
+    op.execute("DROP POLICY IF EXISTS files_owner ON files;")
+    op.execute("DROP POLICY IF EXISTS vaults_owner ON vaults;")
+
+    # Triggers
+    op.execute("DROP TRIGGER IF EXISTS files_updated_at ON files;")
+    op.execute("DROP TRIGGER IF EXISTS vaults_updated_at ON vaults;")
+    op.execute("DROP FUNCTION IF EXISTS update_updated_at;")
+
+    # Tables (order matters due to foreign keys)
+    op.execute("DROP TABLE IF EXISTS chunks;")
+    op.execute("DROP TABLE IF EXISTS files;")
+    op.execute("DROP TABLE IF EXISTS vaults;")


### PR DESCRIPTION
Initialize Supabase database with Alembic migrations

- Version control database schema
- Alembic config (env.py, alembic.ini). vaults/files/chunks/ tables, RLS policies, pgvector